### PR TITLE
docs: Fix Tensorflow's GitHub repository URL

### DIFF
--- a/code/README.md
+++ b/code/README.md
@@ -28,7 +28,7 @@ This repo contains the code to train and evaluate state of the art classificatio
 
 ## Installation
 You need to install :
-- [Theano](https://github.com/Theano/Theano) and [TensorFlow](https://github.com/Theano/Theano). Preferably the last version
+- [Theano](https://github.com/Theano/Theano) and [TensorFlow](https://github.com/tensorflow/tensorflow). Preferably the last version
 - [Keras](https://github.com/fchollet/keras)
 
 ## Run experiments


### PR DESCRIPTION
Replace Theano's URL by Tensorflow's URL